### PR TITLE
Support downloading password-protected files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,4 @@
 * Koticka
 * VladoDriver
 * SpiReCZ
+* [myke](https://github.com/MikulasZelinka)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ s webovým rozhraním.
     minutu, ale stejný link je možné používat po dostahování původní části
     opakovaně pro stahování dalších částí
 * Umí navazovat přerušená stahování (pokud se zachová stejný počet částí)
+* Umí stahovat zaheslované soubory (na straně Ulož.to)
 * Stahuje přímo do finálního souboru, jednotlivá stahování zapisují na správné
   místo v souboru (než program ohlásí dostahováno, je soubor neúplný)
 * Konzolový status panel se statistikou úspěšnosti při získávání linků
@@ -184,6 +185,12 @@ sekvenčně (po dostahování prvního se začne stahovat druhý atd.):
 
 ```shell
 ulozto-downloader --parts 30 "https://ulozto.cz/file/TKvQVDFBEhtL/debian-9-6-0-amd64-netinst-iso" "https://ulozto.cz/file/YPivhc3Jyn9r/debian-live-11-1-0-amd64-mate-iso"
+```
+
+Pro zadání hesla slouží přepínač `--password <heslo>`:
+
+```shell
+ulozto-downloader --parts 30 --password akcniset "https://uloz.to/file/FFwsQeBeMdcY/debian-9-6-0-amd64-netinst-iso"
 ```
 
 Pokud chcete ukládat log do souboru, použijte přepínač `--log <název souboru>`

--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -28,6 +28,10 @@ def run():
         '--parts', metavar='N', type=int, default=20,
         help='Number of parts that will be downloaded in parallel')
     g_main.add_argument(
+        '--password', metavar='P', type=str, default="",
+        help='Optional password if the file is password-protected')
+
+    g_main.add_argument(
         '--output', metavar='DIRECTORY', type=str, default="./",
         help='Directory or full path including file name where output file will be saved')
     g_main.add_argument(
@@ -122,7 +126,7 @@ def run():
 
     try:
         for url in args.urls:
-            d.download(url, args.parts, args.output, args.temp, args.yes, args.conn_timeout)
+            d.download(url, args.parts, args.password, args.output, args.temp, args.yes, args.conn_timeout)
             # do clean only on successful download (no exception)
             d.clean()
     except utils.DownloaderStopped:

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -34,6 +34,8 @@ class Downloader:
     tor: TorRunner
     page: Page
 
+    password: str
+
     def __init__(self, tor: TorRunner, frontend: Type[Frontend], captcha_solver: Type[CaptchaSolver]):
         """Initialize the Downloader.
 
@@ -176,7 +178,7 @@ class Downloader:
         # reuse download link if need
         self.download_url_queue.put(part.download_url)
 
-    def download(self, url: str, parts: int = 10, target_dir: str = "", temp_dir: str = "", do_overwrite: bool = False, conn_timeout=DEFAULT_CONN_TIMEOUT):
+    def download(self, url: str, parts: int = 10, password: str = "", target_dir: str = "", temp_dir: str = "", do_overwrite: bool = False, conn_timeout=DEFAULT_CONN_TIMEOUT):
         """Download file from Uloz.to using multiple parallel downloads.
             Arguments:
                 url: URL of the Uloz.to file to download
@@ -184,6 +186,7 @@ class Downloader:
                 target_dir: Directory where the download should be saved (default: current directory)
                 do_overwrite: Overwrite files without asking
                 temp_dir: Directory where temporary files will be created (default: current directory)
+                password: Optional password to access the Uloz.to file
         """
         self.url = url
         self.parts = parts
@@ -204,7 +207,7 @@ class Downloader:
         self.log("Getting info (filename, filesize, …)")
 
         try:
-            self.page = Page(url, temp_dir, parts, self.tor, self.conn_timeout)
+            self.page = Page(url, temp_dir, parts, password, self.tor, self.conn_timeout)
             page = self.page  # shortcut
             page.parse()
 


### PR DESCRIPTION
Previously, you would simply obtain an error when encountering a password-protected file (status code `401`).

Downloading these is now supported by either:
- using the `--password <password>` flag, or
- ~interactively providing the password to the script when it asks for it (i.e., when it encounters a `401`)~.

For testing purposes, here's a password-protected link to the Debian ISO:
- https://uloz.to/file/FFwsQeBeMdcY/debian-9-6-0-amd64-netinst-iso
- `akcniset`

Both of these commands should work identically, though the first one doesn't require interaction:
- `ulozto-downloader --auto-captcha --password akcniset --parts 10 "https://uloz.to/file/FFwsQeBeMdcY/debian-9-6-0-amd64-netinst-iso"`
- `ulozto-downloader --auto-captcha --parts 10 "https://uloz.to/file/FFwsQeBeMdcY/debian-9-6-0-amd64-netinst-iso"`