### PR TITLE
Podpora Windows and macOS (Python 3.8+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/**
 build/**
 uld.egg-info/**
+ulozto_downloader.egg-info/**
 uldlib/__pycache__/**
 parser.py
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools  # noqa
 
 from uldlib import __version__
 
-with open("README.md", "r") as fh:
+with open("README.md", "r",encoding='utf8') as fh:
     long_description = fh.read()
 
 setup(

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -378,8 +378,3 @@ class Downloader:
             str(timedelta(seconds=round(elapsed))),
             round(speed / 1024**2, 2)
         ))
-        # remove resume .udown file
-        udown_file = output_filename + DOWNPOSTFIX
-        if os.path.exists(udown_file):
-            print(f"Delete file: {udown_file}")
-            os.remove(udown_file)

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -50,7 +50,8 @@ class Downloader:
         if hasattr(self, "processes") and self.processes is not None:
             self.stop_download.set()
             for p in self.processes:
-                p.terminate()
+                if platform.system() == 'Windows':
+                    p.join()
         print('Download terminated.')
         if hasattr(self, "monitor") and self.monitor is not None:
             self.stop_monitor.set()

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -349,7 +349,7 @@ class Downloader:
         # 4. Wait for all downloads to finish
         success = True
         for p in self.processes:
-            p.join()
+            while p.is_alive():  p.join(1)
             if p.exitcode != 0:
                 success = False
 

--- a/uldlib/segfile.py
+++ b/uldlib/segfile.py
@@ -167,5 +167,8 @@ class SegFileMonitor:
 
     def clean(self):
         if self.file_size is not None:
+            if not self.sfp.closed:
+                self.sfp.close()
             if os.path.exists(self.progfile):
                 os.remove(self.progfile)
+                print(f'Removed file {self.sfp.name}')


### PR DESCRIPTION
**Toto je náhrada za: https://github.com/setnicka/ulozto-downloader/pull/77 trochu jsem zkoušel [git-filter-repo](https://github.com/newren/git-filter-repo) a nějak se to rozsypalo :blush:  :slightly_smiling_face: 
 Sorry!**

Multiprocessing ve windows neumí pro linux defaultní fork při startu nového procesu a proto musí do nového procesu přesunovat stav s mateřského procesu pomocí [pickle](https://docs.python.org/3/library/pickle.html), a pickle modul rozhodně nepodporuje všechny konstrukce pythonu.
Pokud by to někoho zajímalo tak tady jdou hodně do podrobna: [win vs linux](https://rhodesmill.org/brandon/2010/python-multiprocessing-linux-windows/), [picklingerror-crash](https://chrissardegna.com/blog/multiprocessing-changes-python-3-8/#picklingerror-crash)

Tohle všechno co se snaží python zapicklovat:
``` 
.{'captcha_solve_func': <uldlib.captcha.AutoReadCaptcha object at 0x00000000045658B0>,
'cli_initialized': True,
'monitor': <Process name='Process-2' pid=5808 parent=5592 started>,
'url': 'https://uloz.to/file/VTDU6sN6mm8s/ubuntu-20-04-4-live-server-amd64-iso',
'parts': 5, 'processes': [],
'captcha_process': <Process name='Process-1' parent=5592 initial>,
'target_dir': './', 'terminating': False, 'isLimited': True, 'isCaptcha': True,
'download_type': 'CAPTCHA protected download',
'captcha_download_links_generator': <generator object Page.captcha_download_links_generator at 0x000000000456FF90>,
'download_url_queue': <multiprocess.queues.Queue object at 0x0000000003C8B130>}
```
Vyzkoušel jsem [balíček multiprocess](https://github.com/uqfoundation/multiprocess) , který místo pickle používá [dill](https://dill.readthedocs.io/en/latest/index.html), ale ani ten si neporadí s generátorem případně z něj vytvořeným iterátorem.

Možná by to zvládl [ray](https://github.com/ray-project/ray) , který dostal nedávno podporu pro generátory, ale nějak na to už nemám sílu :slightly_smiling_face: 

Nakonec jsem zvolil variantu ve win se úplně procesům vyhnout a použít threading. Multiprocessing.dummy má takřka shodné api s multiprocessing, jenom procesy a vlákna se ukončují kapku jinak, jak jsem zjistil :slightly_smiling_face: , takže jsem použil [multiprocessing.Event](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Event).

Všechno jsem otestoval na ```win7 + python38```  a ```ubuntu 21.10 + python39``` Stahuje bez problémů, CTRL+C je ve win trochu pomalejší, win10 nevedu.

Podle mě by na všechno stačily thready, stahování souborů je řádově pomalejší a procesor na něj stejně čeká, ale třeba mi něco uniká nebo se prostě pletu. Rozhodně respektuju cestu, kterou se rozhodli jít autoři, případný merge potěší, ale zamítnutí nezarmoutí :slightly_smiling_face: 

Pokud chce někdo otestovat:
```pip install git+https://github.com/zbyna/ulozto-downloader.git@multiprocessingdummy#egg=ulozto-downloader ```
