### PR TITLE
Frontend rework

### DIFF
--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -4,6 +4,7 @@ import signal
 from os import path
 from uldlib import downloader, captcha, __version__, __path__
 from uldlib.const import DEFAULT_CONN_TIMEOUT
+from uldlib.frontend import ConsoleFrontend
 
 
 def run():
@@ -25,15 +26,17 @@ def run():
 
     args = parser.parse_args()
 
+    # TODO: implement other frontends and allow to choose from them
+    frontend = ConsoleFrontend()
+
     if args.auto_captcha:
         model_path = path.join(__path__[0], "model.tflite")
         model_download_url = "https://github.com/JanPalasek/ulozto-captcha-breaker/releases/download/v2.2/model.tflite"
-        captcha_solve_fnc = captcha.AutoReadCaptcha(
-            model_path, model_download_url)
+        solver = captcha.AutoReadCaptcha(model_path, model_download_url, frontend)
     else:
-        captcha_solve_fnc = captcha.tkinter_user_prompt
+        solver = captcha.ManualInput(frontend)
 
-    d = downloader.Downloader(captcha_solve_fnc)
+    d = downloader.Downloader(frontend, solver)
 
     # Register sigint handler
     def sigint_handler(sig, frame):

--- a/uldlib/frontend.py
+++ b/uldlib/frontend.py
@@ -1,0 +1,216 @@
+
+from abc import abstractmethod
+from datetime import timedelta
+import colors
+import os
+import sys
+import time
+import threading
+from typing import Dict, List, Tuple
+
+from uldlib.const import CLI_STATUS_STARTLINE
+from uldlib.part import DownloadPart
+from uldlib.utils import LogLevel
+
+
+class DownloadInfo:
+    filename: str
+    url: str
+    download_type: str
+    total_size: int
+    part_size: int
+    parts: int
+
+
+class Frontend():
+
+    @abstractmethod
+    def captcha_log(self, msg: str, level: LogLevel = LogLevel.INFO):
+        pass
+
+    @abstractmethod
+    def captcha_stats(self, stats: Dict[str, int]):
+        pass
+
+    @abstractmethod
+    def main_log(self, msg: str, level: LogLevel = LogLevel.INFO):
+        pass
+
+    @abstractmethod
+    def prompt(self, msg: str, level: LogLevel = LogLevel.INFO) -> str:
+        pass
+
+    @abstractmethod
+    def run(self, parts: List[DownloadPart], stop_event: threading.Event):
+        pass
+
+
+class ConsoleFrontend(Frontend):
+    cli_initialized: bool
+
+    last_log: Tuple[str, LogLevel]
+
+    last_captcha_log: Tuple[str, LogLevel]
+    last_captcha_stats: Dict[str, int]
+
+    def __init__(self):
+        self.cli_initialized = False
+        self.last_log = ("", LogLevel.INFO)
+        self.last_captcha_log = ("", LogLevel.INFO)
+        self.last_captcha_stats = None
+
+    def captcha_log(self, msg: str, level: LogLevel = LogLevel.INFO):
+        self.last_captcha_log = (msg, level)
+        if not self.cli_initialized:
+            sys.stdout.write(colors.blue(
+                "[Link solve]\t") + self._color(msg, level) + "\033[K\r")
+
+    def captcha_stats(self, stats: Dict[str, int]):
+        self.last_captcha_stats = stats
+
+    def main_log(self, msg: str, level: LogLevel = LogLevel.INFO):
+        self.last_log = (msg, level)
+
+        if self.cli_initialized:
+            return
+        print(self._color(msg, level))
+
+    def prompt(self, msg: str, level: LogLevel = LogLevel.INFO) -> str:
+        print(self._color(msg, level), end="")
+        return input().strip()
+
+    @staticmethod
+    def _stat_fmt(stats: Dict[str, int]):
+        count = colors.blue(stats['all'])
+        ok = colors.green(stats['ok'])
+        bad = colors.red(stats['bad'])
+        lim = colors.red(stats['lim'])
+        blo = colors.red(stats['block'])
+        net = colors.red(stats['net'])
+        return f"[Ok: {ok} / {count}] :( [Badcp: {bad} Limited: {lim} Censored: {blo} NetErr: {net}]"
+
+    @staticmethod
+    def _print(text, x=0, y=0):
+        sys.stdout.write("\033[{};{}H".format(y, x))
+        sys.stdout.write("\033[K")
+        sys.stdout.write(text)
+        sys.stdout.flush()
+
+    @staticmethod
+    def _color(text: str, level: LogLevel) -> str:
+        if level == LogLevel.WARNING:
+            return colors.yellow(text)
+        if level == LogLevel.ERROR:
+            return colors.red(text)
+        if level == LogLevel.SUCCESS:
+            return colors.green(text)
+        return text
+
+    def run(self, info: DownloadInfo, parts: List[DownloadPart], stop_event: threading.Event):
+        os.system('cls' if os.name == 'nt' else 'clear')
+        sys.stdout.write("\033[?25l")  # hide cursor
+        self.cli_initialized = True
+
+        print(colors.blue("File:\t\t") + colors.bold(info.filename))
+        print(colors.blue("URL:\t\t") + info.url)
+        print(colors.blue("Download type:\t") + info.download_type)
+        print(colors.blue("Size / parts: \t") +
+              colors.bold(f"{round(info.total_size / 1024**2, 2)}MB => " +
+              f"{info.parts} x {round(info.part_size / 1024**2, 2)}MB"))
+
+        t_start = time.time()
+        s_start = 0
+        for part in parts:
+            (_, _, size) = part.get_frontend_status()
+            s_start += size
+        last_bps = [(s_start, t_start)]
+
+        while True:
+            if stop_event.is_set():
+                break
+
+            t = time.time()
+            # Get parts info
+            lines = []
+            s = 0
+            for part in parts:
+                (line, level, size) = part.get_frontend_status()
+                lines.append(self._color(line, level))
+                s += size
+
+            # Print parts
+            for (line, part) in zip(lines, parts):
+                self._print(
+                    colors.blue(f"[Part {part.id}]") + f"\t{line}",
+                    y=(part.id + CLI_STATUS_STARTLINE))
+
+            y = info.parts + CLI_STATUS_STARTLINE
+
+            # Print CAPTCHA/TOR status
+            (msg, level) = self.last_captcha_log
+            self._print(
+                colors.yellow("[Link solve]\t") +
+                self._color(msg, level),
+                y=y
+            )
+            y += 1
+            if self.last_captcha_stats is not None:
+                self._print(
+                    colors.yellow("\t\t") + self._stat_fmt(self.last_captcha_stats),
+                    y=y
+                )
+                y += 1
+
+            # Print overall progress line
+            if t == t_start:
+                total_bps = 0
+                now_bps = 0
+            else:
+                total_bps = (s - s_start) / (t - t_start)
+                # Average now bps for last 10 measurements
+                if len(last_bps) >= 10:
+                    last_bps = last_bps[1:]
+                (s_last, t_last) = last_bps[0]
+                now_bps = (s - s_last) / (t - t_last)
+                last_bps.append((s, t))
+
+            remaining = (info.total_size - s) / total_bps if total_bps > 0 else 0
+
+            self._print(colors.yellow(
+                f"[Progress]\t"
+                f"{(s / 1024 ** 2):.2f} MB"
+                f" ({(s / info.total_size * 100):.2f} %)"
+                f"\tavg. speed: {(total_bps / 1024 ** 2):.2f} MB/s"
+                f"\tcurr. speed: {(now_bps / 1024 ** 2):.2f} MB/s"
+                f"\tremaining: {timedelta(seconds=round(remaining))}"),
+                y=y
+            )
+            y += 1
+
+            # Print last log message
+            (msg, level) = self.last_log
+            self._print(
+                colors.yellow("[STATUS]\t") +
+                self._color(msg, level),
+                y=y
+            )
+            y += 1
+
+            time.sleep(0.5)
+
+        if self.cli_initialized:
+            sys.stdout.write("\033[{};{}H".format(y + 2, 0))
+            sys.stdout.write("\033[?25h")  # show cursor
+            self.cli_initialized = False
+
+        elapsed = time.time() - t_start
+        # speed in bytes per second:
+        speed = (s - s_start) / elapsed if elapsed > 0 else 0
+        print(colors.blue("Statistics:\t") + "Downloaded {}{} MB in {} (average speed {} MB/s)".format(
+            round((s - s_start) / 1024**2, 2),
+            "" if s_start == 0 else (
+                "/"+str(round(info.total_size / 1024**2, 2))
+            ),
+            str(timedelta(seconds=round(elapsed))),
+            round(speed / 1024**2, 2)
+        ))

--- a/uldlib/part.py
+++ b/uldlib/part.py
@@ -1,3 +1,5 @@
+import threading
+
 from uldlib.segfile import SegFileWriter
 
 
@@ -9,8 +11,36 @@ class DownloadPart:
     success: bool = False
     exception: Exception = None
 
+    # Lock and protected variables (used by status thread)
+    lock: threading.Lock
+    started: bool
+    completed: bool
+    error: bool
+    warning: bool
+    status: str
     start_time: float
+    completion_time: float
+    size: int
+    d_now: int
+    d_total: int
 
     def __init__(self, writer: SegFileWriter):
         self.writer = writer
         self.id = writer.id
+        self.lock = threading.Lock()
+
+        # Init empty status
+        self.started = False
+        self.completed = False
+        self.error = False
+        self.status = ""
+        self.size = writer.size
+        self.d_now = 0
+        self.d_total = writer.written
+
+    def set_status(self, status: str, error: bool = False, warning: bool = False):
+        self.lock.acquire()
+        self.status = status
+        self.error = error
+        self.warning = warning
+        self.lock.release()

--- a/uldlib/part.py
+++ b/uldlib/part.py
@@ -1,5 +1,10 @@
 import threading
+import time
 
+from datetime import timedelta
+from typing import Tuple
+
+from uldlib.utils import LogLevel
 from uldlib.segfile import SegFileWriter
 
 
@@ -44,3 +49,52 @@ class DownloadPart:
         self.error = error
         self.warning = warning
         self.lock.release()
+
+    def get_frontend_status(self) -> Tuple[str, LogLevel, int]:
+        """
+        Returns status line for given part
+        """
+
+        level = LogLevel.INFO
+        self.lock.acquire()
+        downloaded = self.d_total
+
+        if self.error:
+            msg = self.status if self.status else "ERROR: Unknown error"
+            level = LogLevel.ERROR
+        elif self.warning:
+            msg = self.status if self.status else "WARNING: Unknown warning"
+            level = LogLevel.WARNING
+        elif self.status and self.completed:
+            msg = self.status
+            level = LogLevel.SUCCESS
+        elif self.status:
+            msg = self.status
+        elif self.completed:
+            elapsed = self.completion_time - self.start_time
+            speed = self.d_now / elapsed if elapsed > 0 else 0
+            msg = "Successfully downloaded {}{} MB in {} (speed {} KB/s)".format(
+                round(self.d_now / 1024**2, 2),
+                "" if self.d_now == self.d_total else (
+                    "/"+str(round(self.d_total / 1024**2, 2))
+                ),
+                str(timedelta(seconds=round(elapsed))),
+                round(speed / 1024, 2)
+            )
+            level = LogLevel.SUCCESS
+        else:
+            elapsed = time.time() - self.start_time
+            speed = self.d_now / elapsed if elapsed > 0 else 0
+            # remaining time in seconds:
+            remaining = (self.size - self.d_total) / speed if speed > 0 else 0
+
+            msg = "{:.2f}%\t{:.2f}/{:.2f} MB\tspeed: {:.2f} KB/s\telapsed: {}\tremaining: {}".format(
+                round(self.d_total / self.size * 100, 2),
+                round(self.d_total / 1024**2, 2), round(self.size / 1024**2, 2),
+                round(speed / 1024, 2),
+                str(timedelta(seconds=round(elapsed))),
+                str(timedelta(seconds=round(remaining))),
+            )
+
+        self.lock.release()
+        return (msg, level, downloaded)

--- a/uldlib/utils.py
+++ b/uldlib/utils.py
@@ -1,29 +1,8 @@
-import sys
-import colors
-from . import const
-
-def _print(text, x=0, y=0):
-    sys.stdout.write("\033[{};{}H".format(y, x))
-    sys.stdout.write("\033[K")
-    sys.stdout.write(text)
-    sys.stdout.flush()
+from enum import Enum
 
 
-def print_part_status(id, text):
-    _print(colors.blue(f"[Part {id}]") + f"\t{text}",
-           y=(id + const.CLI_STATUS_STARTLINE))
-
-
-def print_captcha_status(text, parts):
-    _print(colors.yellow("[Link solve]") +
-           f"\t{text}", y=(parts + 0 + const.CLI_STATUS_STARTLINE))
-
-
-def print_tor_status(text, parts):
-    _print(colors.yellow("[Tor  start]") +
-           f"\t{text}", y=(parts + 0 + const.CLI_STATUS_STARTLINE))
-
-
-def print_saved_status(text, parts):
-    _print(colors.yellow(f"[Progress]\t {text}"),
-           y=(parts + 1 + const.CLI_STATUS_STARTLINE))
+class LogLevel(Enum):
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
+    SUCCESS = 4


### PR DESCRIPTION
This humongous patch separates download core from the frontend. It will make any new frontends (web, …) and batch usage of the ulozto-downloader much more easy to make.

Previously every worker writes to the console independently (only targeting the right console row). Now every worker saves data in the DownloadPart struct, from where teh data is taken by some frontend.

Frontend is injected as dependency using Frontend abstract class which defines API interface between core and the frontend. It is not yet stable, some changes will be probably needed in the future. Now only the ConsoleFrontend is implemented.

It would be nice to refactor it using ncurses (it is possible now, because only one process writes to the console).

Also CaptchaSolver abstract class was developed, primarily to allow easy passing of the log func for the CAPTCHA part. As side effect it also provides nice defined API :)