### PR TITLE
Odstranění požadavku na tflite_runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ ansicolors
 numpy
 pysocks
 stem
-tflite-runtime


### PR DESCRIPTION
Odstranění požadavku na tflite_runtime z důvodu následné nekompatibility s Termux a nutnosti jako první nainstalovat na windows tflite_runtime.