### PR TITLE
Corectly remove output_filename+DOWNPOSTFIX (.udown) file

### DIFF
--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -61,7 +61,7 @@ class Downloader:
         self.stop_frontend.set()
         if self.frontend_thread:
             self.frontend_thread.join()
-
+        
     def _captcha_breaker(self, page, parts):
         msg = ""
         if page.isDirectDownload:
@@ -318,3 +318,6 @@ class Downloader:
             sys.exit(1)
 
         self.log("All downloads successfully finished", level=LogLevel.SUCCESS)
+        # need remove udown file
+        if os.path.isfile(output_filename+DOWNPOSTFIX):
+            os.remove(output_filename+DOWNPOSTFIX)


### PR DESCRIPTION
<output_file>.udown not removed after all segments downloaded. After continue already downloaded file this cause of error:

`Terminating download. Please wait for stopping all threads.9-6-0-amd64-netinst-iso
Exception in thread Thread-1 (run):ownload
Traceback (most recent call last):82MB
  File "/home/vlado/.local/lib/python3.10/site-packages/uldlib/frontend.py", line 111, in run
    self._loop(info, parts, stop_event)10/site-packages/uldlib/frontend.py", line 111, in run
  File "/home/vlado/.local/lib/python3.10/site-packages/uldlib/frontend.py", line 223, in _loop
    speed = (s - s_start) / elapsed if elapsed > 0 else 0ldlib/frontend.py", line 223, in _loop
UnboundLocalError: local variable 's' referenced before assignment
UnboundLocalError: local variable 's' referenced before assignment
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/vlado/.local/lib/python3.10/site-packages/uldlib/frontend.py", line 120, in run
    terminate_func()
  File "/home/vlado/.local/lib/python3.10/site-packages/uldlib/downloader.py", line 57, in terminate
    self.captcha_thread.join()
  File "/usr/lib/python3.10/threading.py", line 1091, in join
    raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started
`