### PR TITLE
Allow to hide parts progress

### DIFF
--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -34,7 +34,7 @@ def run():
     args = parser.parse_args()
 
     # TODO: implement other frontends and allow to choose from them
-    frontend = ConsoleFrontend(args)
+    frontend = ConsoleFrontend(show_parts=args.parts_progress)
 
     tflite_available = importlib.util.find_spec('tflite_runtime')
     tkinter_available = importlib.util.find_spec('tkinter')

--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -19,6 +19,8 @@ def run():
                         help="URL from Uloz.to (tip: enter in 'quotes' because the URL contains ! sign)")
     parser.add_argument('--parts', metavar='N', type=int, default=20,
                         help='Number of parts that will be downloaded in parallel')
+    parser.add_argument('--parts-progress', default=False, action='store_true',
+                        help='Show progress of parts while being downloaded')
     parser.add_argument('--output', metavar='DIRECTORY',
                         type=str, default="./", help='Target directory')
     parser.add_argument('--auto-captcha', default=False, action="store_true",
@@ -32,7 +34,7 @@ def run():
     args = parser.parse_args()
 
     # TODO: implement other frontends and allow to choose from them
-    frontend = ConsoleFrontend()
+    frontend = ConsoleFrontend(args)
 
     tflite_available = importlib.util.find_spec('tflite_runtime')
     tkinter_available = importlib.util.find_spec('tkinter')

--- a/uldlib/frontend.py
+++ b/uldlib/frontend.py
@@ -47,19 +47,19 @@ class Frontend():
 
 class ConsoleFrontend(Frontend):
     cli_initialized: bool
-    show_parts_progress: bool
+    show_parts: bool
 
     last_log: Tuple[str, LogLevel]
 
     last_captcha_log: Tuple[str, LogLevel]
     last_captcha_stats: Dict[str, int]
 
-    def __init__(self, args):
+    def __init__(self, show_parts: bool = False):
         self.cli_initialized = False
         self.last_log = ("", LogLevel.INFO)
         self.last_captcha_log = ("", LogLevel.INFO)
         self.last_captcha_stats = None
-        self.show_parts_progress = args.parts_progress
+        self.show_parts = show_parts
 
     def captcha_log(self, msg: str, level: LogLevel = LogLevel.INFO):
         self.last_captcha_log = (msg, level)
@@ -208,7 +208,7 @@ class ConsoleFrontend(Frontend):
             y += 1
 
             # Print parts
-            if self.show_parts_progress:
+            if self.show_parts:
                 for (line, part) in zip(lines, parts):
                     self._print(
                         colors.blue(f"[Part {part.id}]") + f"\t{line}",

--- a/uldlib/frontend.py
+++ b/uldlib/frontend.py
@@ -47,17 +47,19 @@ class Frontend():
 
 class ConsoleFrontend(Frontend):
     cli_initialized: bool
+    show_parts_progress: bool
 
     last_log: Tuple[str, LogLevel]
 
     last_captcha_log: Tuple[str, LogLevel]
     last_captcha_stats: Dict[str, int]
 
-    def __init__(self):
+    def __init__(self, args):
         self.cli_initialized = False
         self.last_log = ("", LogLevel.INFO)
         self.last_captcha_log = ("", LogLevel.INFO)
         self.last_captcha_stats = None
+        self.show_parts_progress = args.parts_progress
 
     def captcha_log(self, msg: str, level: LogLevel = LogLevel.INFO):
         self.last_captcha_log = (msg, level)
@@ -153,13 +155,7 @@ class ConsoleFrontend(Frontend):
                 lines.append(self._color(line, level))
                 s += size
 
-            # Print parts
-            for (line, part) in zip(lines, parts):
-                self._print(
-                    colors.blue(f"[Part {part.id}]") + f"\t{line}",
-                    y=(part.id + CLI_STATUS_STARTLINE))
-
-            y = info.parts + CLI_STATUS_STARTLINE
+            y = CLI_STATUS_STARTLINE
 
             # Print CAPTCHA/TOR status
             (msg, level) = self.last_captcha_log
@@ -210,6 +206,13 @@ class ConsoleFrontend(Frontend):
                 y=y
             )
             y += 1
+
+            # Print parts
+            if self.show_parts_progress:
+                for (line, part) in zip(lines, parts):
+                    self._print(
+                        colors.blue(f"[Part {part.id}]") + f"\t{line}",
+                        y=(y + part.id))
 
             time.sleep(0.5)
 


### PR DESCRIPTION
solves #110

Adds new arg to allow hiding parts progress for files with too many parts and show overall progress on top.

![Screenshot from 2022-09-27 22-47-53](https://user-images.githubusercontent.com/11539820/192633977-4a21fb68-e664-4395-a253-329243e9f60b.png)
![Screenshot from 2022-09-27 22-49-03](https://user-images.githubusercontent.com/11539820/192634001-a4be0157-ba5f-403e-8154-e252971a713a.png)
