### PR TITLE
Add Docker image

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           context: "{{defaultContext}}"
           push: true
-          tags: "ghcr.io/${{IMAGE_REPOSITORY}}:${{IMAGE_TAG}}"
+          tags: "ghcr.io/${{env.IMAGE_REPOSITORY}}:${{env.IMAGE_TAG}}"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,6 +27,7 @@ jobs:
 
   build-docker-image:
     runs-on: ubuntu-latest
+    needs: build-and-publish
     steps:
       -
         name: Set up Docker Buildx

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -50,4 +50,4 @@ jobs:
         with:
           context: "{{defaultContext}}"
           push: true
-          tags: "ghcr.io/${{env.IMAGE_REPOSITORY}}:${{env.IMAGE_TAG}}"
+          tags: "ghcr.io/${{env.IMAGE_REPOSITORY}}:${{env.IMAGE_TAG}},ghcr.io/${{env.IMAGE_REPOSITORY}}:latest"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,10 +38,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Prepare image name
+        run: |
+          echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+          echo IMAGE_TAG=$(echo ${{ github.ref_name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
       -
         name: Build and push image
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}"
           push: true
-          tags: "ghcr.io/${{github.repository}}:${{github.ref_name}}"
+          tags: "ghcr.io/${{IMAGE_REPOSITORY}}:${{IMAGE_TAG}}"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,3 +24,24 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_api_token }}
+
+  build-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: "{{defaultContext}}"
+          push: true
+          tags: ghcr.io/{{ github.repository }}:{{ github.ref_name }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           context: "{{defaultContext}}"
           push: true
-          tags: ghcr.io/{{ github.repository }}:{{ github.ref_name }}
+          tags: "ghcr.io/${{github.repository}}:${{github.ref_name}}"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,6 @@ jobs:
 
   build-docker-image:
     runs-on: ubuntu-latest
-    needs: build-and-publish
     steps:
       -
         name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ RUN apt update && apt install tor -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install tflite-runtime ulozto-downloader
+
+ENTRYPOINT ["ulozto-downloader", "--output", "/downloads/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.9-slim-bullseye
+
+RUN apt update && apt install tor -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install tflite-runtime ulozto-downloader


### PR DESCRIPTION
This PR adds Dockerfile that builds container image with tor and all dependecies. Container image is build on publish to pypi and stored in github container registry. 

After merging and creating release, new image will be pushed to `ghcr.io/setnicka/ulozto-downloader:latest`  

Docs should be updated with this simple command how to download files.

```bash
docker run -t -v <path to downloads>:/downloads/ ghcr.io/setnicka/ulozto-downloader:latest --parts 50 "https://ulozto.cz/file/TKvQVDFBEhtL/debian-9-6-0-amd64-netinst-iso"
```