### PR TITLE
JsonFrontend for use in script

### DIFF
--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -5,13 +5,13 @@ import os
 import sys
 from os import path
 from uldlib import downloader, captcha, __version__, __path__, const
-from uldlib.frontend import ConsoleFrontend, JsonFrontend
+from uldlib.frontend import ConsoleFrontend, JSONFrontend
 from uldlib import utils
 from uldlib.torrunner import TorRunner
 from uldlib.utils import LogLevel
 
 # TODO Automatic find all types implementing Frontend and put into this dict
-avaiable_frontends = { "console": ConsoleFrontend, "JSON": JsonFrontend }
+avaiable_frontends = { "console": ConsoleFrontend, "JSON": JSONFrontend }
 
 def run():
     parser = argparse.ArgumentParser(

--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -10,6 +10,8 @@ from uldlib import utils
 from uldlib.torrunner import TorRunner
 from uldlib.utils import LogLevel
 
+# TODO Automatic find all types implementing Frontend and put into this dict
+avaiable_frontends = { "console": ConsoleFrontend, "JSON": JsonFrontend }
 
 def run():
     parser = argparse.ArgumentParser(
@@ -33,16 +35,13 @@ def run():
     parser.add_argument('--log', metavar='LOGFILE', type=str, default="",
                         help="Enable logging to given file")
     parser.add_argument('--version', action='version', version=__version__)
-    parser.add_argument('--script', default=False, action="store_true",
-                        help="Use JsonFrontend to produce JSON progress output for use in script")
+    parser.add_argument('--frontend', type=str, default="console", choices=avaiable_frontends.keys(),
+                        help="Select frontend: 'console' - text user interface for humans, 'JSON' - output for scripts")
 
     args = parser.parse_args()
 
-    # TODO: implement other frontends and allow to choose from them
-    if args.script:
-        frontend = JsonFrontend(show_parts=args.parts_progress, logfile=args.log)
-    else:
-        frontend = ConsoleFrontend(show_parts=args.parts_progress, logfile=args.log)
+    # Use user chosen frontend
+    frontend = avaiable_frontends[args.frontend](show_parts=args.parts_progress, logfile=args.log)
 
     tfull_available = importlib.util.find_spec('tensorflow') and importlib.util.find_spec('tensorflow.lite')
     tflite_available = importlib.util.find_spec('tflite_runtime')

--- a/uldlib/frontend.py
+++ b/uldlib/frontend.py
@@ -267,7 +267,7 @@ class ConsoleFrontend(Frontend):
             round(speed / 1024**2, 2)
         ))
 
-class JsonFrontend(Frontend):
+class JSONFrontend(Frontend):
     show_parts: bool
     logfile: Optional[TextIOWrapper] = None
 
@@ -335,7 +335,7 @@ class JsonFrontend(Frontend):
             terminate_func()
 
     def _loop(self, info: DownloadInfo, parts: List[DownloadPart], stop_event: threading.Event):
-        jsonReport = JsonReport(info)
+        jsonReport = JSONReport(info)
 
         t_start = time.time()
         s_start = 0
@@ -379,7 +379,7 @@ class JsonFrontend(Frontend):
 
         print(json.dumps({"status": Status.COMPLETED, "duration": str(timedelta(seconds=round(elapsed))), "avg_speed": f"{round(speed / 1024**2, 2)} MB/s"}))
 
-class JsonReport:
+class JSONReport:
     status: str
     file: str
     url: str

--- a/uldlib/frontend.py
+++ b/uldlib/frontend.py
@@ -7,12 +7,13 @@ import os
 import sys
 import time
 import threading
+import json
 from typing import Dict, List, Optional, Tuple
 
 from uldlib import utils
 from uldlib.const import CLI_STATUS_STARTLINE
 from uldlib.part import DownloadPart
-from uldlib.utils import LogLevel
+from uldlib.utils import LogLevel, Status
 
 
 class DownloadInfo:
@@ -265,3 +266,183 @@ class ConsoleFrontend(Frontend):
             str(timedelta(seconds=round(elapsed))),
             round(speed / 1024**2, 2)
         ))
+
+class JsonFrontend(Frontend):
+    cli_initialized: bool
+    show_parts: bool
+    logfile: Optional[TextIOWrapper] = None
+
+    last_log: Tuple[str, LogLevel]
+
+    last_captcha_log: Tuple[str, LogLevel]
+    last_captcha_stats: Dict[str, int]
+
+    def __init__(self, show_parts: bool = False, logfile: str = ""):
+        super().__init__(supports_prompt=True)
+        self.cli_initialized = False
+        self.last_log = ("", LogLevel.INFO)
+        self.last_captcha_log = ("", LogLevel.INFO)
+        self.last_captcha_stats = None
+        self.show_parts = show_parts
+        if logfile:
+            self.logfile = open(logfile, 'a')
+        print(json.dumps({"status": Status.INITIALIZING}))
+
+    def __del__(self):
+        if self.logfile:
+            self.logfile.close()
+
+    @staticmethod
+    def _log_print(msg: str, progress: bool):
+        if progress:
+            sys.stdout.write(msg + "\033[K\r")
+        else:
+            print(msg)
+
+    def _log_logfile(self, prefix: str, msg: str, progress: bool, level: LogLevel):
+        if progress or self.logfile is None:
+            return
+
+        t = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.logfile.write(f"{t} {prefix}\t[{level.name}] {msg}\n")
+        self.logfile.flush()
+
+    def tor_log(self, msg: str, level: LogLevel = LogLevel.INFO, progress: bool = False):
+        #print(json.dumps({"status": msg}))
+        pass
+
+    def captcha_log(self, msg: str, level: LogLevel = LogLevel.INFO, progress: bool = False):
+        #print(json.dumps({"status": msg}))
+        pass
+
+    def main_log(self, msg: str, level: LogLevel = LogLevel.INFO, progress: bool = False):
+        if LogLevel == LogLevel.ERROR:
+            print(json.dumps({"status": Status.ERROR, "message": msg}))
+        else:
+            #print(json.dumps({"status": msg}))
+            pass
+
+    def captcha_stats(self, stats: Dict[str, int]):
+        self.last_captcha_stats = stats
+
+    def prompt(self, msg: str, level: LogLevel = LogLevel.INFO) -> str:
+        #print(utils.color(msg, level), end="")
+        return input().strip()
+
+    @staticmethod
+    def _stat_fmt(stats: Dict[str, int]):
+        count = colors.blue(stats['all'])
+        ok = colors.green(stats['ok'])
+        bad = colors.red(stats['bad'])
+        lim = colors.red(stats['lim'])
+        blo = colors.red(stats['block'])
+        net = colors.red(stats['net'])
+        return f"[Ok: {ok} / {count}] :( [Badcp: {bad} Limited: {lim} Censored: {blo} NetErr: {net}]"
+
+    @staticmethod
+    def _print(text, x=0, y=0):
+        sys.stdout.write("\033[{};{}H".format(y, x))
+        sys.stdout.write("\033[K")
+        sys.stdout.write(text)
+        sys.stdout.flush()
+
+    def run(self, info: DownloadInfo, parts: List[DownloadPart], stop_event: threading.Event, terminate_func):
+        try:
+            self._loop(info, parts, stop_event)
+        except Exception:
+            if self.cli_initialized:
+                y = info.parts + CLI_STATUS_STARTLINE + 4
+                sys.stdout.write("\033[{};{}H".format(y, 0))
+                sys.stdout.write("\033[?25h")  # show cursor
+                self.cli_initialized = False
+                print("")
+            print_exc()
+            terminate_func()
+
+    def _loop(self, info: DownloadInfo, parts: List[DownloadPart], stop_event: threading.Event):
+        self.cli_initialized = True
+
+        jsonReport = JsonReport(info)
+
+        t_start = time.time()
+        s_start = 0
+        for part in parts:
+            (_, _, size) = part.get_frontend_status()
+            s_start += size
+        last_bps = [(s_start, t_start)]
+
+        y = 0
+
+        while True:
+            t = time.time()
+            # Get parts info
+            lines = []
+            s = 0
+            for part in parts:
+                (line, level, size) = part.get_frontend_status()
+                lines.append(utils.color(line, level))
+                s += size
+
+            # Print overall progress line
+            if t == t_start:
+                total_bps = 0
+                now_bps = 0
+            else:
+                total_bps = (s - s_start) / (t - t_start)
+                # Average now bps for last 10 measurements
+                if len(last_bps) >= 10:
+                    last_bps = last_bps[1:]
+                (s_last, t_last) = last_bps[0]
+                now_bps = (s - s_last) / (t - t_last)
+                last_bps.append((s, t))
+
+            remaining = (info.total_size - s) / total_bps if total_bps > 0 else 0
+
+            jsonReport.update(s, total_bps, now_bps, remaining)
+            print(jsonReport)
+
+            if stop_event.is_set():
+                break
+
+            time.sleep(0.5)
+
+        if self.cli_initialized:
+            y = info.parts + CLI_STATUS_STARTLINE + 4
+            sys.stdout.write("\033[{};{}H".format(y + 2, 0))
+            sys.stdout.write("\033[?25h")  # show cursor
+            self.cli_initialized = False
+
+        elapsed = time.time() - t_start
+        # speed in bytes per second:
+        speed = (s - s_start) / elapsed if elapsed > 0 else 0
+
+        print(json.dumps({"status": Status.COMPLETED, "duration": str(timedelta(seconds=round(elapsed))), "avg_speed": f"{round(speed / 1024**2, 2)} MB/s"}))
+
+class JsonReport:
+    status: str
+    file: str
+    url: str
+    size: str
+    downloaded: str
+    percent: str
+    avg_speed: str
+    curr_speed: str
+    remaining: str
+    size_float: float
+
+    def __init__(self, info: DownloadInfo) -> None:
+        self.status = Status.DOWNLOADING
+        self.file = info.filename,
+        self.url = info.url,
+        self.size = f"{round(info.total_size / 1024**2, 2)} MB"
+        self.size_float = info.total_size
+
+    def update(self, down_size, total_bps, now_bps, remaining):
+        self.downloaded = f"{(down_size / 1024 ** 2):.2f} MB",
+        self.percent = f"{(down_size / self.size_float * 100):.2f} %",
+        self.avg_speed = f"{(total_bps / 1024 ** 2):.2f} MB/s",
+        self.curr_speed = f"{(now_bps / 1024 ** 2):.2f} MB/s",
+        self.remaining = f"{timedelta(seconds=round(remaining))}"
+
+    def __str__(self) -> str:
+        return json.dumps(self.__dict__).replace('["', '"').replace('"]', '"')

--- a/uldlib/frontend.py
+++ b/uldlib/frontend.py
@@ -306,11 +306,11 @@ class JSONFrontend(Frontend):
         self.logfile.flush()
 
     def tor_log(self, msg: str, level: LogLevel = LogLevel.INFO, progress: bool = False):
-        #print(json.dumps({"status": msg}))
+        print(json.dumps({"tor": msg}))
         pass
 
     def captcha_log(self, msg: str, level: LogLevel = LogLevel.INFO, progress: bool = False):
-        #print(json.dumps({"status": msg}))
+        print(json.dumps({"captcha": msg}))
         pass
 
     def main_log(self, msg: str, level: LogLevel = LogLevel.INFO, progress: bool = False):
@@ -403,7 +403,7 @@ class JSONReport:
         self.percent = f"{(down_size / self.size_float * 100):.2f} %",
         self.avg_speed = f"{(total_bps / 1024 ** 2):.2f} MB/s",
         self.curr_speed = f"{(now_bps / 1024 ** 2):.2f} MB/s",
-       
+        
         remaining = (self.size_float - down_size) / total_bps if total_bps > 0 else 0
         self.remaining = f"{timedelta(seconds=round(remaining))}"
 

--- a/uldlib/utils.py
+++ b/uldlib/utils.py
@@ -9,6 +9,11 @@ class LogLevel(Enum):
     ERROR = 3
     SUCCESS = 4
 
+class Status(str, Enum):
+    INITIALIZING: str = "initializing",
+    DOWNLOADING: str = "downloading",
+    COMPLETED: str = "completed",
+    ERROR: str = "error"
 
 def color(text: str, level: LogLevel) -> str:
     if level == LogLevel.WARNING:


### PR DESCRIPTION
This PR adds option to use `--script` command line argument. This argument uses new JsonFrontend which is inspired with output from YT-DLP  `--newline --progress-template %(progress)j `.

Original ConsoleFrontend rewrites progress inline every 0.5s which is convinient for human eyes but cannot be easily used in scripts. 

JsonFrontend instead produces newline every 0.5s with easily deserializable JSON string.

![image](https://user-images.githubusercontent.com/48015347/201312481-72e8dcfe-ee23-4789-8541-d50da2d80dcf.png)
