### PR TITLE
Update page.py

### DIFF
--- a/uldlib/page.py
+++ b/uldlib/page.py
@@ -286,6 +286,9 @@ class Page:
                     self.linkCache.add(dlink)
                     self.numTorLinks += 1
                     yield dlink
+                elif self.isDirectDownload:
+                    solver.log("Direct download does no seem to work, trying with captcha resolution instead...")
+                    self.isDirectDownload = False
 
             except requests.exceptions.ConnectionError:
                 self._error_net_stat(


### PR DESCRIPTION
The direct download detection does not seem to work reliably (e. g. with this link: https://ulozto.sk/file/13FjXnBCUleC/the-white-lotus-s02e01-2022-web-dl-1080p-ukr-eng-hurtom-mkv where the downloader detects the link to be directly downloadable without captcha, but then is actually presented one and cannot handle it anymore).

The downloader in this case loops forever trying unsuccessfully to obtain a download link.

The proposed patch makes the downloader retry in "captcha detection" mode once the direct download fails.