### PR TITLE
Better handling of HTTP 425 Too Early status code

### DIFF
--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -124,11 +124,14 @@ class Downloader:
                 "Connection": "close",
             })
 
-            if r.status_code != 429:
+            if r.status_code == 429:
+                part.set_status("Status code 429 Too Many Requests returned… will try again in few seconds", warning=True)
+                time.sleep(5)
+            elif r.status_code == 425:
+                part.set_status("Status code 425 Too Early returned… will try again in few seconds", warning=True)
+                time.sleep(5)
+            else:
                 break
-
-            part.set_status("Status code 429 Too Many Requests returned… will try again in few seconds", warning=True)
-            time.sleep(5)
 
         if r.status_code != 206 and r.status_code != 200:
             part.set_status(f"Status code {r.status_code} returned: {writer.pfrom + writer.written}/{writer.pto}", error=True)


### PR DESCRIPTION
When HTTP status 425 is returned from the remote server, the part download stops and the whole downloader process needs to be restarted.

This patch allows the part download to back off and retry again in such cases.