### PR TITLE
Enhance output dir parameter functionality

### DIFF
--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -29,7 +29,7 @@ def run():
         help='Number of parts that will be downloaded in parallel')
     g_main.add_argument(
         '--output', metavar='DIRECTORY', type=str, default="./",
-        help='Directory where output file will be saved')
+        help='Directory or full path including file name where output file will be saved')
     g_main.add_argument(
         '--temp', metavar='DIRECTORY', type=str, default="./",
         help='Directory where temporary files (.ucache, .udown, Tor data directory) will be created')

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -212,9 +212,12 @@ class Downloader:
             raise DownloaderError('Cannot download file: ' + str(e))
 
         # Do check - only if .udown status file not exists get question
-        self.output_filename = os.path.join(target_dir, page.filename)
-        self.stat_filename = os.path.join(temp_dir, page.filename + DOWNPOSTFIX)
-        self.filename = page.filename
+        if not os.path.isdir(target_dir):
+            self.output_filename = target_dir
+        else:
+            self.output_filename = os.path.join(target_dir, page.filename)
+        self.filename = os.path.basename(self.output_filename)
+        self.stat_filename = os.path.join(temp_dir, self.filename + DOWNPOSTFIX)
         # .udown file is always present in cli_mode = False
         if os.path.isfile(self.output_filename) and not os.path.isfile(self.stat_filename):
             if self.frontend.supports_prompt and not do_overwrite:
@@ -227,7 +230,7 @@ class Downloader:
                          .format(self.output_filename), level=LogLevel.WARNING)
 
         info = DownloadInfo()
-        info.filename = page.filename
+        info.filename = self.filename
         info.url = page.url
 
         if page.quickDownloadURL is not None:

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -211,13 +211,18 @@ class Downloader:
         except Exception as e:
             raise DownloaderError('Cannot download file: ' + str(e))
 
-        # Do check - only if .udown status file not exists get question
-        if not os.path.isdir(target_dir):
+        # Check of the target is a file or directory and construct the output path accordingly
+        if not os.path.isdir(target_dir) and target_dir[-1] != '/':
+            # Path to a file has been provided
             self.output_filename = target_dir
         else:
+            # Create the output directory if does not exist
+            os.makedirs(target_dir, exist_ok = True)
             self.output_filename = os.path.join(target_dir, page.filename)
         self.filename = os.path.basename(self.output_filename)
         self.stat_filename = os.path.join(temp_dir, self.filename + DOWNPOSTFIX)
+        
+        # Do check - only if .udown status file not exists get question
         # .udown file is always present in cli_mode = False
         if os.path.isfile(self.output_filename) and not os.path.isfile(self.stat_filename):
             if self.frontend.supports_prompt and not do_overwrite:

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -222,6 +222,8 @@ class Downloader:
         self.filename = os.path.basename(self.output_filename)
         self.stat_filename = os.path.join(temp_dir, self.filename + DOWNPOSTFIX)
         
+        self.log("Downloading into: '{}'".format(self.output_filename))
+        
         # Do check - only if .udown status file not exists get question
         # .udown file is always present in cli_mode = False
         if os.path.isfile(self.output_filename) and not os.path.isfile(self.stat_filename):


### PR DESCRIPTION
Added better processing of the value of the --output parameter allowing the user to provide a destination file name in the path. 

In case the provided value a directory, the autodetected file name is used, otherwise the value is assumed to be a full destination path.

If the provided directory does not exists, it will be created.