### PR TITLE
Added --enfoce-tor option

### DIFF
--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -62,7 +62,12 @@ def run():
     g_captcha.add_argument(
         '--manual-captcha', default=False, action="store_true",
         help='Solve CAPTCHAs by manual input')
-    g_captcha.add_argument(
+    
+    g_tor = parser.add_argument_group("TOR related options")
+    g_tor.add_argument(
+        '-t', '--enforce-tor', default=False, action="store_true",
+        help='Perform all the connections via TOR. If not set, the initial connection to Ulozto is performed directly before TOR is launched')
+    g_tor.add_argument(
         '--conn-timeout', metavar='SEC', default=const.DEFAULT_CONN_TIMEOUT, type=int,
         help='Set connection timeout for TOR sessions in seconds')
 
@@ -132,7 +137,7 @@ def run():
 
     try:
         for url in args.urls:
-            d.download(url, args.parts, args.password, args.output, args.temp, args.yes, args.conn_timeout)
+            d.download(url, args.parts, args.password, args.output, args.temp, args.yes, args.conn_timeout, args.enforce_tor)
             # do clean only on successful download (no exception)
             d.clean()
     except utils.DownloaderStopped:

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -178,7 +178,7 @@ class Downloader:
         # reuse download link if need
         self.download_url_queue.put(part.download_url)
 
-    def download(self, url: str, parts: int = 10, password: str = "", target_dir: str = "", temp_dir: str = "", do_overwrite: bool = False, conn_timeout=DEFAULT_CONN_TIMEOUT):
+    def download(self, url: str, parts: int = 10, password: str = "", target_dir: str = "", temp_dir: str = "", do_overwrite: bool = False, conn_timeout=DEFAULT_CONN_TIMEOUT, enforce_tor = False):
         """Download file from Uloz.to using multiple parallel downloads.
             Arguments:
                 url: URL of the Uloz.to file to download
@@ -191,6 +191,7 @@ class Downloader:
         self.url = url
         self.parts = parts
         self.conn_timeout = conn_timeout
+        self.enforce_tor = enforce_tor
 
         self.threads = []
         self.terminating = False
@@ -214,7 +215,8 @@ class Downloader:
                 password=password,
                 frontend=self.frontend,
                 tor=self.tor,
-                conn_timeout=self.conn_timeout,
+                enforce_tor=self.enforce_tor,
+                conn_timeout=self.conn_timeout
             )
             page = self.page  # shortcut
             page.parse()


### PR DESCRIPTION
The pull request reverts the original behavior where initial requests to Ulozto are made directly and only captcha solving requests are routed through the TOR network.

The --enforce-tor option is added to optionally enable the new behavior where all connections are routed via TOR.