### PR TITLE
Freeze colorama to version >=0.4.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests
 Pillow
 ansicolors
-colorama
+colorama>=0.4.6
 numpy
 pysocks
 stem


### PR DESCRIPTION
This solves and issue where older versions of `colorama` do not work. This can also serve as a guide for packagers.
Closes #165