### PR TITLE
Never overwrite flag

### DIFF
--- a/uldlib/cmd.py
+++ b/uldlib/cmd.py
@@ -43,6 +43,9 @@ def run():
     g_main.add_argument(
         '-y', '--yes', default=False, action="store_true",
         help='Overwrite files without asking')
+    g_main.add_argument(
+        '-n', '--never', default=False, action="store_true",
+        help='Never overwrite files')
 
     g_log = parser.add_argument_group("Display and logging options")
     g_log.add_argument(
@@ -140,7 +143,7 @@ def run():
 
     try:
         for url in args.urls:
-            d.download(url, args.parts, args.password, args.output, args.temp, args.yes, args.conn_timeout, args.enforce_tor)
+            d.download(url, args.parts, args.password, args.output, args.temp, args.yes, args.never, args.conn_timeout, args.enforce_tor)
             # do clean only on successful download (no exception)
             d.clean()
     except utils.DownloaderStopped:

--- a/uldlib/downloader.py
+++ b/uldlib/downloader.py
@@ -178,7 +178,7 @@ class Downloader:
         # reuse download link if need
         self.download_url_queue.put(part.download_url)
 
-    def download(self, url: str, parts: int = 10, password: str = "", target_dir: str = "", temp_dir: str = "", do_overwrite: bool = False, conn_timeout=DEFAULT_CONN_TIMEOUT, enforce_tor = False):
+    def download(self, url: str, parts: int = 10, password: str = "", target_dir: str = "", temp_dir: str = "", do_overwrite: bool = False, never_overwrite: bool = False, conn_timeout=DEFAULT_CONN_TIMEOUT, enforce_tor = False):
         """Download file from Uloz.to using multiple parallel downloads.
             Arguments:
                 url: URL of the Uloz.to file to download
@@ -240,6 +240,11 @@ class Downloader:
         # Do check - only if .udown status file not exists get question
         # .udown file is always present in cli_mode = False
         if os.path.isfile(self.output_filename) and not os.path.isfile(self.stat_filename):
+            if never_overwrite:
+                self.log("WARNING: File '{}' already exists, and never overwrite flag has been set. Skipping download .."
+                         .format(self.output_filename), level=LogLevel.WARNING)
+                raise DownloaderStopped()
+                
             if self.frontend.supports_prompt and not do_overwrite:
                 answer = self.frontend.prompt(
                     "WARNING: File '{}' already exists, overwrite it? [y/n] ".format(self.output_filename), level=LogLevel.WARNING)


### PR DESCRIPTION
Adding an commandline flag to make sure the downloader newer overwrites if a file already exists.
Adds a new flag called -n, --never

I didn't find a good way to combine it with the -y, --yes flags.. 
